### PR TITLE
Fix deployment to gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,18 @@ jobs:
       run: npm run build
       working-directory: webpage
 
+    - name: Create gh-pages branch if it doesn't exist
+      run: |
+        git fetch origin
+        if [ `git branch -r | grep 'origin/gh-pages'` ]; then
+          git checkout gh-pages
+        else
+          git checkout --orphan gh-pages
+          git reset --hard
+          git commit --allow-empty -m "Initial commit"
+          git push origin gh-pages
+        fi
+
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Add a step to create the `gh-pages` branch if it does not exist in the `deploy.yml` file.

* Add a step to fetch remote branches using `git fetch origin`.
* Check if the `gh-pages` branch exists using `git branch -r | grep 'origin/gh-pages'`.
* If the branch exists, checkout the `gh-pages` branch.
* If the branch does not exist, create an orphan `gh-pages` branch, commit an empty commit, and push it to the remote.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/go-llm-chat/pull/3?shareId=3af94a04-79c0-4d1d-afa9-327ae2c0ede0).