### PR TITLE
Fix GitHub Pages deployment issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
 
@@ -29,7 +29,7 @@ jobs:
     - name: Create gh-pages branch if it doesn't exist
       run: |
         git fetch origin
-        if [ `git branch -r | grep 'origin/gh-pages'` ]; then
+        if git show-ref --quiet refs/remotes/origin/gh-pages; then
           git checkout gh-pages
         else
           git checkout --orphan gh-pages


### PR DESCRIPTION
Update GitHub Actions workflow to fix GitHub Pages deployment issue.

* Update `actions/checkout` to use `v3` instead of `v2`.
* Update `actions/setup-node` to use `v3` instead of `v2`.
* Ensure dependencies are correctly installed and built.
* Handle creation of `gh-pages` branch correctly.
* Include updated steps for deploying to GitHub Pages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/go-llm-chat/pull/5?shareId=3f5a6c61-209e-42ec-b55a-8d2b1dd17565).