### PR TITLE
Add debug step to list installed dependencies in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
       run: npm install
       working-directory: webpage
 
+    - name: Debug: List dependencies
+      run: npm list
+      working-directory: webpage
+
     - name: Build static site
       run: npm run build
       working-directory: webpage


### PR DESCRIPTION
Add a debug step to the GitHub Actions workflow to list installed dependencies.

* Add a debug step using `npm list` after the "Install dependencies" step.
* Ensure the debug step uses the `working-directory` of `webpage`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/go-llm-chat/pull/6?shareId=39c3f0c8-ae3d-4754-bde9-58a205591f0f).